### PR TITLE
Add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ tmp*
 examples/attic
 cache
 out
+
+# direnv
+/.direnv/
+
+#nix
+/result
+/result/
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1719317636,
+        "narHash": "sha256-bu0xbu2Z6DDzA9LGV81yJunIti6r7tjUImeR8orAL/I=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9c513fc6fb75142f6aec6b7545cb8af2236b80f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "hm-typecheck";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = ins:
+    ins.flake-utils.lib.eachDefaultSystem (system : let
+      pkgs = import ins.nixpkgs { inherit system; };
+      gitignore = pkgs.nix-gitignore.gitignoreSourcePure [ ./.gitignore ];
+      ghcPkgs = pkgs.haskell.packages.ghc925;
+      hmPkgs = ghcPkgs.override {
+        overrides = self: super: rec {
+          hm = (self.callCabal2nix "hm" (gitignore ./.) {});
+          megaparsec = super.megaparsec_9_6_1;
+        };
+      };
+    in {
+      packages = rec {
+        hm = hmPkgs.hm;
+        default = hm;
+      };
+      devShells.default = ghcPkgs.shellFor {
+        packages = _: [ hmPkgs.hm ];
+        buildInputs = with ghcPkgs; [
+          cabal-install
+          haskell-language-server
+        ];
+      };
+    });
+}
+


### PR DESCRIPTION
Adds a flake.nix to make life easy for those so inclined. Note that this does not interfere with the ghcup / cabal based workflows in any way, and uses `hm.cabal` as the source of truth.